### PR TITLE
removing an old fromBufferGeometry() call that slipped through

### DIFF
--- a/dist/aframe-physics-system.js
+++ b/dist/aframe-physics-system.js
@@ -16484,7 +16484,7 @@ module.exports = AFRAME.registerComponent("ammo-constraint", {
 
     const bodyTransform = body
       .getCenterOfMassTransform()
-      .inverse()
+      .invert()
       .op_mul(targetBody.getWorldTransform());
     const targetTransform = new Ammo.btTransform();
     targetTransform.setIdentity();
@@ -17002,7 +17002,7 @@ let AmmoBody = {
       } else {
         q1.set(quaternion.x(), quaternion.y(), quaternion.z(), quaternion.w());
         parentEl.object3D.getWorldQuaternion(q2);
-        q1.multiply(q2.inverse());
+        q1.multiply(q2.invert());
         el.object3D.quaternion.copy(q1);
 
         v.set(position.x(), position.y(), position.z());
@@ -17406,7 +17406,7 @@ var Body = {
       } else {
         q1.copy(body.quaternion);
         parentEl.object3D.getWorldQuaternion(q2);
-        q1.premultiply(q2.inverse());
+        q1.premultiply(q2.invert());
         el.object3D.quaternion.copy(q1);
 
         v.copy(body.position);

--- a/dist/aframe-physics-system.js
+++ b/dist/aframe-physics-system.js
@@ -1,3 +1,6 @@
+// https://raw.githubusercontent.com/gearcoded/aframe-physics-system/master/dist/aframe-physics-system.js
+// https://github.com/gearcoded/aframe-physics-system/blob/master/dist/aframe-physics-system.js
+// https://github.com/n5ro/aframe-physics-system/issues/187#issuecomment-792048570
  
 (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 var CANNON = require('cannon');
@@ -15830,7 +15833,7 @@ function getGeometry (object) {
       if (mesh.geometry.attributes.position
           && mesh.geometry.attributes.position.itemSize > 2) {
         var tmpGeom = new THREE.BufferGeometry();
-        tmpGeom.fromBufferGeometry(mesh.geometry);
+        // tmpGeom.fromBufferGeometry(mesh.geometry);
         combined.merge(tmpGeom, mesh.matrixWorld);
         tmpGeom.dispose();
       }


### PR DESCRIPTION
Caught a fromBufferGeometry() call that applies to the old Geometry but not the new BufferGeometry. Just commented it out allowed this basic super-hands example to work: https://glitch.com/edit/#!/super-hands-demo?path=aframe-physics-system.js%3A15828%3A0

Notice that there are many inverse -> invert warnings. I have fixed this in a pull request that has been merged upstream that you should pull.

Also added some links at top of file so it is clear to anyone looking that this is a temporary fork to give context.